### PR TITLE
Add podman support as alternative container runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ nano .env  # Add your API keys (see below)
 cd ~/your-project
 claude-docker
 
+# Optional: use `claude-docker --podman` or `DOCKER=podman claude-docker`
+# to use podman instead of docker.
+#
 # Optional: Set up SSH keys for git push (see Prerequisites section)
 # The script will show setup instructions if keys are missing
 ```
@@ -48,6 +51,7 @@ Claude Docker supports several command-line flags for different use cases:
 ### Basic Usage
 ```bash
 claude-docker                    # Start Claude in current directory
+claude-docker --podman           # Use podman instead of docker to run containers
 claude-docker --continue         # Resume previous conversation in this directory
 claude-docker --rebuild          # Force rebuild Docker image
 claude-docker --rebuild --no-cache  # Rebuild without using Docker cache
@@ -57,6 +61,7 @@ claude-docker --rebuild --no-cache  # Rebuild without using Docker cache
 
 | Flag | Description | Example |
 |------|-------------|---------|
+| `--podman` | Use podman in place of docker | `claude-docker --podman` |
 | `--continue` | Resume the previous conversation in current directory | `claude-docker --continue` |
 | `--rebuild` | Force rebuild of the Docker image | `claude-docker --rebuild` |
 | `--no-cache` | When rebuilding, don't use Docker cache | `claude-docker --rebuild --no-cache` |

--- a/project.md
+++ b/project.md
@@ -6,6 +6,7 @@ The `claude-docker.sh` script provides a comprehensive wrapper for running Claud
 ## Core Components
 
 ### 1. Command Line Arguments
+- `--podman`: Use Podman instead of Docker (can set path to docker/podman with DOCKER env var)
 - `--no-cache`: Skip Docker build cache
 - `--rebuild`: Force image rebuild
 - `--continue`: Pass continue flag to Claude

--- a/src/claude-docker.sh
+++ b/src/claude-docker.sh
@@ -3,6 +3,7 @@
 # ABOUTME: Handles project mounting, .claude setup, and environment variables
 
 # Parse command line arguments
+DOCKER="${DOCKER:-docker}"
 NO_CACHE=""
 FORCE_REBUILD=false
 CONTINUE_FLAG=""
@@ -12,6 +13,10 @@ ARGS=()
 
 while [[ $# -gt 0 ]]; do
     case $1 in
+        --podman)
+            DOCKER=podman
+            shift
+            ;;
         --no-cache)
             NO_CACHE="--no-cache"
             shift
@@ -88,7 +93,7 @@ fi
 # Check if we need to rebuild the image
 NEED_REBUILD=false
 
-if ! docker images | grep -q "claude-docker"; then
+if ! "$DOCKER" images | grep -q "claude-docker"; then
     echo "Building Claude Docker image for first time..."
     NEED_REBUILD=true
 fi
@@ -123,7 +128,7 @@ if [ "$NEED_REBUILD" = true ]; then
         BUILD_ARGS="$BUILD_ARGS --build-arg SYSTEM_PACKAGES=\"$SYSTEM_PACKAGES\""
     fi
     
-    eval "docker build $NO_CACHE $BUILD_ARGS -t claude-docker:latest \"$PROJECT_ROOT\""
+    eval "'$DOCKER' build $NO_CACHE $BUILD_ARGS -t claude-docker:latest \"$PROJECT_ROOT\""
     
     # Clean up copied auth files
     rm -f "$PROJECT_ROOT/.claude.json"
@@ -198,7 +203,7 @@ fi
 # Add GPU access if specified
 if [ -n "$GPU_ACCESS" ]; then
     # Check if nvidia-docker2 or nvidia-container-runtime is available
-    if docker info 2>/dev/null | grep -q nvidia || which nvidia-docker >/dev/null 2>&1; then
+    if "$DOCKER" info 2>/dev/null | grep -q nvidia || which nvidia-docker >/dev/null 2>&1; then
         echo "✓ Enabling GPU access: $GPU_ACCESS"
         DOCKER_OPTS="$DOCKER_OPTS --gpus $GPU_ACCESS"
     else
@@ -262,7 +267,7 @@ fi
 
 # Run Claude Code in Docker
 echo "Starting Claude Code in Docker..."
-docker run -it --rm \
+"$DOCKER" run -it --rm \
     $DOCKER_OPTS \
     -v "$CURRENT_DIR:/workspace" \
     -v "$HOME/.claude-docker/claude-home:/home/claude-user/.claude:rw" \


### PR DESCRIPTION
Allow users to run claude-docker with podman instead of docker by using
--podman flag or setting DOCKER environment variable to podman path.
